### PR TITLE
Add CI using github actions

### DIFF
--- a/.github/problem-matchers/compiler-non-source.json
+++ b/.github/problem-matchers/compiler-non-source.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "__comment_owner": "match compiler warning/error lines not from source",
+            "owner": "compiler-non-source",
+            "pattern": [
+                {
+                    "__comment_regexp1": "clang: warning: argument unused during compilation: '-march=armv7-a' [-Wunused-command-line-argument]",
+                    "__comment_regexp2": "ld.lld: warning: lld uses blx instruction, no object with architecture supporting feature detected",
+                    "regexp": "^(?:[^:]+): (?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "severity": 1,
+                    "message": 2
+                }
+            ]
+        }
+    ]
+}

--- a/.github/problem-matchers/compiler-source.json
+++ b/.github/problem-matchers/compiler-source.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc-problem-matcher",
+            "pattern": [
+                {
+                    "regexp": "^(?:/linux/)?(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,84 @@
+name: CI
+
+# Controls when the workflow will run.
+on:
+  # This allows the build to be triggered manually via the github UI.
+  workflow_dispatch:
+
+  # Push to any branch
+  push:
+
+  # Any pull request
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        host: [x86_64-linux-gnu, powerpc-linux-gnu, powerpc64-linux-gnu, powerpc64le-linux-gnu]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Register problem matchers
+      run: |
+        echo "::add-matcher::.github/problem-matchers/compiler-source.json"
+        echo "::add-matcher::.github/problem-matchers/compiler-non-source.json"
+
+    - name: Install cross compiler
+      if: matrix.host != 'x86_64-linux-gnu'
+      run: |
+        sudo apt update
+        sudo apt install -y gcc-${{ matrix.host }}
+
+    - name: autogen
+      run: ./autogen.sh
+
+    - name: configure
+      run: ./configure --host=${{ matrix.host }}
+
+    - name: make
+      run: make -j $(nproc)
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: vdsotest-${{ matrix.host }}
+        path: |
+          ./vdsotest
+          ./vdsotest-all
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    strategy:
+      matrix:
+        host: [x86_64-linux-gnu]
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: vdsotest-${{ matrix.host }}
+
+    - name: set permissions
+      run: chmod u+x vdsotest vdsotest-all
+
+    - name: vdsotest-all
+      run: vdsotest=./vdsotest ./vdsotest-all
+
+  distcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: autogen
+      run: ./autogen.sh
+
+    - name: configure
+      run: ./configure
+
+    - name: distcheck
+      run: make distcheck


### PR DESCRIPTION
Add basic CI using github actions, based on the linuxppc github actions.

Includes builds for x86_64/powerpc/powerpc64/powerpc64le, distcheck and runs vdsotest-all for x86_64. A further improvement would be to run the tests for other architectures using qemu.

Closes #1 

Signed-off-by: Michael Ellerman <mpe@ellerman.id.au>